### PR TITLE
Dependabot updates will now occur monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "./.github/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       separator: "-"
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "./frontend/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       separator: "-"
@@ -32,7 +32,7 @@ updates:
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "./backend/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       separator: "-"


### PR DESCRIPTION
This PR modifies the dependabot file to configure the bot to perform updates monthly instead of weekly.

Closes #77 