### PR TITLE
Submit button now occupies fullwidth on sm screens

### DIFF
--- a/frontend/src/components/buttons/SubmitUrlButton.tsx
+++ b/frontend/src/components/buttons/SubmitUrlButton.tsx
@@ -10,7 +10,9 @@ const SubmitUrlButton = (props: SubmitUrlButtonProps) => {
 
   return (
     <Button className="submit-button" type="submit" disabled={submitting}>
-      {submitting ? <ButtonSpinner /> : "Prune"}
+      {submitting ?
+        <ButtonSpinner />
+      : "Submit"}
     </Button>
   );
 };

--- a/frontend/src/styles/_buttons.scss
+++ b/frontend/src/styles/_buttons.scss
@@ -1,5 +1,11 @@
+@use "bootstrap";
+
 .submit-button {
   width: 75px;
+
+  @media screen and (max-width: #{map-get(bootstrap.$grid-breakpoints, sm)}) {
+    width: 100%;
+  }
 }
 
 .copy-button {


### PR DESCRIPTION
This PR introduces a styling change where the submit button occupies the full-width of the sm screen.

Closes #48 