### PR TITLE
Add permissions to .NET test workflow

### DIFF
--- a/.github/workflows/build_test_dotnet.yml
+++ b/.github/workflows/build_test_dotnet.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "**"
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   build_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR introduces explicit permissions to the .NET test workflow so that dependabot PRs can have code coverage results published.

Fixes #107 